### PR TITLE
New and more stable version of OpenAL implementation

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,16 @@
 Port of OpenAL to Made With Marmalade 
 
-Definitely supports mono output. 
+Supports both stereo and mono output.
 
-Was recently patched up a contributor to add stereo output. There are a few people using it who have posted issues/fixes in the issues section, so check that out if you have problems. 
+This version should be stable on all platforms - it has been tested on PC, Android and iOS.
+Stable means that OpenAL and s3e sound thread and application are properly synchronized, it means that it won't freeze or crash your application on device suspend/resume, and that it won't hang your application when it should be closed.
+
+Only negative side is that current implementation has lot of cracking in the sound on PC, but luckily on Android and iPhone/iPad/iPod it sounds good without cracking.
+
+
+Once Marmalade is fixed to allow mutex locks inside s3e callback, this player should be rewritten, as then you wouldn't need worker thread but could call aluMixData() directly from s3e sound callback. That implementation should both be faster and give better sound quality than this implementation. So if you have  problems with this implementation, complain to Marmalade to allow mutex locks inside s3e sound callback :)
+
+
+
+There are a few people using it who have posted issues/fixes in the issues section, so check that out if you have problems. 
 

--- a/openal-soft-1.13/Alc/s3esoundaudio.c
+++ b/openal-soft-1.13/Alc/s3esoundaudio.c
@@ -7,53 +7,109 @@
 #include "AL/alc.h"
 #include <s3eSound.h>
 #include <s3eThread.h>
+#include <s3eDevice.h>
+#include <s3eTimer.h>
 
 
 static const ALCchar s3eDevice[] = "s3eSound";
 
-typedef struct {
-    int channel;
-
+typedef struct _s3e_data {
+    // s3e sound channel ID
+    int                     channel;
+    // Buffer used to play sound with s3e
     ALubyte*                mix_data;
-    volatile int            killNow;
+    // Size of single sample mixed in advance
+    int                     sampleSize;
+    // Bytes per sound sample - we use 2 or 4 bytes
+    // depending if we play mono or stereo sound
+    int                     bytesPerSample;
+    // If true, we're playing stereo sound
+    int                     isStereo;
 
-    volatile ALvoid*        thread;     // Has to be volatile, it can change in different threads
-    s3eSoundGenAudioInfo*   thread_info;
+    // Pre-buffer data (cyclic or ring buffer)
+    // Stereo sound - use uint32
+    ALubyte*                preBufferData;
+    // Maximum size of pre-buffer data
+    int                     preBufferSize;
+    // Pointer where is start of usable data
+    volatile int            preBuffer_DataStartIndex;
+    // How much usable (already mixed) data is in the buffer
+    volatile int            preBuffer_DataLength;
+    // If true, it means that data in pre-buffer is ready
+    // to be send to sound channel
+    volatile int            preBuffer_IsDataReady;
+
+    // Pointer to worker thread
+    // It has to be volatile, it can change in different threads
+    volatile ALvoid*        thread;
+    // If true, we should immediately exit worker thread
+    volatile int            killNow;
+    // Semaphore used for synchronization between 
+    // s3e callback function and worker thread
     s3eThreadSem*           thread_semaphore;
-    volatile int            thread_finishedWorking;
+    // If true, worker thread is closed
     volatile int            thread_exited;
 } s3e_data;
 
 
-static ALuint s3e_channel_thread(ALvoid *ptr)
+static ALuint s3e_channel_thread( ALvoid *ptr )
 {
     ALCdevice *Device = (ALCdevice*)ptr;
     s3e_data *data = (s3e_data*)Device->ExtraData;
+    int samplesToMix, idx1, len1, len2;
     data->thread_exited = 0;
+
+    // This thread will pre-mix sound data into internal buffer
+    // so when s3e sound callback is called, he just has to 
+    // copy data from that buffer... And then we get signal
+    // to pre-mix some more data for next s3e sound callback.
 
     // It is very important that this thread reacts ASAP to
     // signal from s3e callback, so the main s3e thread is
     // not paused for too long.
     // Luckily, we can use semaphore to wait for signal from
-    // s3e callback function, that way we react immediately.
+    // s3e callback function, that way we react almost immediately.
 
-    while( !data->killNow )
+    while( !data->killNow && !s3eDeviceCheckQuitRequest() )
     {
+        assert( data->preBuffer_IsDataReady == 0 );
+
+        if( data->preBuffer_DataLength == 0 ) data->preBuffer_DataStartIndex = 0;
+
+        // Mix the data in the circular (ring) buffer
+        //samplesToMix = data->preBufferSize - data->preBuffer_DataLength;    // Always fill buffer to the max
+        samplesToMix = min( data->sampleSize, data->preBufferSize - data->preBuffer_DataLength );
+
+        // Mix data in two steps - first mix from the end of the buffer
+        idx1 = (data->preBuffer_DataStartIndex + data->preBuffer_DataLength);
+        if( idx1 >= data->preBufferSize ) idx1 -= data->preBufferSize;
+        len1 = min( data->preBufferSize - idx1, samplesToMix );
+        if( len1 > 0 ) aluMixData( Device, data->preBufferData + idx1*data->bytesPerSample, len1 );
+        // Mix 2nd step - from start of the buffer
+        len2 = samplesToMix - len1;
+        if( len2 > 0 ) aluMixData( Device, data->preBufferData, len2 );
+        assert( len2 <= data->preBuffer_DataStartIndex );
+
+
+        // Ok, sound data mixed
+        data->preBuffer_DataLength += samplesToMix;
+
+        // Mark it that we have data ready
+        data->preBuffer_IsDataReady = 1;
+
         // Wait for s3e main thread to signal us via semaphore
-        if( s3eThreadSemWait(data->thread_semaphore, 10) != S3E_RESULT_SUCCESS ) {
+        // before we start mixing again
+        s3eDeviceYield(0);
+        while( !data->killNow && s3eThreadSemWait(data->thread_semaphore, 10) != S3E_RESULT_SUCCESS )
+        {
+            s3eDeviceYield(0);
+
             // Waited 10ms, but without any signal - just check if we need
             // to close this thread, and then wait again
-            continue;
+            if( s3eDeviceCheckQuitRequest() ) data->killNow = 1;
+
+            // Wait another 10ms for signal from s3e callback
         }
-        assert(data->thread_finishedWorking == 0);
-
-        // Mix the data... Now OpenAL can lock its mutex without Marmalade reporting error
-        aluMixData(Device, data->thread_info->m_Target, data->thread_info->m_NumSamples);
-
-        // Signal to s3e callback function that we're finished with mixing the data
-        // We have to use volatile varialble instead of semaphore or lock (mutex)
-        // because Marmalade doesn't allow locking of the s3e thread
-        data->thread_finishedWorking = 1;
     }
 
     data->thread_exited = 1;
@@ -61,14 +117,19 @@ static ALuint s3e_channel_thread(ALvoid *ptr)
 }
 
 
-int32 s3e_more_audio(void* systemData, void* userData)
+int32 s3e_more_audio( void* systemData, void* userData )
 {
-    // This code assumes that s3e_more_audio won't be called while
-    // we're already in it.
+    // This code assumes that the function s3e_more_audio 
+    // won't be called while we're already in it.
     // That is because this function is called only from the
     // s3e main thread, and it has to wait for us to exit this 
     // function before it can call it again
+    // NOTE: Inside this function we can't call s3eDeviceYield()
+    // or any other sleep function, because if we do, s3e sound
+    // callback 
 
+    int dataWritten, len1, len2;
+    uint64 startTime;
     ALCdevice *pDevice = (ALCdevice*)userData;
     s3eSoundGenAudioInfo* info = (s3eSoundGenAudioInfo*)systemData;
     s3e_data* data;
@@ -76,78 +137,148 @@ int32 s3e_more_audio(void* systemData, void* userData)
     if( systemData == NULL || userData == NULL ) return 0;
     data = (s3e_data*)pDevice->ExtraData;
 
+    assert( (data->isStereo!=0) == (info->m_Stereo!=0) );
+
     // Check if this channel is actually closed or should be closed
-    if( data == NULL || data->killNow || data->thread == NULL || data->thread_exited ) {
+    if( data == NULL || data->killNow || data->thread == NULL || data->thread_exited )
+    {
         info->m_EndSample = S3E_TRUE;
-        return 0;
+        // If we would return 0 - as we should - s3e will not detect that
+        // application is closed and will call our function again immediately.
+        // So we return info->m_NumSamples so application will be closed properly.
+        // We clear output sound buffer so it would at least play silence.
+        //memset( info->m_Target, 0, info->m_NumSamples * data->bytesPerSample );
+        return info->m_NumSamples;
+        // We can't return 0 even though the app should be closed.
+        // It would actually crash the app as s3e will delete 
+        // sound buffer in next call, and then again call us
+        // which would mean that functions params systemData
+        // and userData would have invalid values!
+        //return 0;
     }
 
-    // We can't call aluMixData() directly, because in it it calls mutex lock
-    // and s3e doesn't allow callback functions to lock the main s3e thread
-    //aluMixData(pDevice, info->m_Target, info->m_NumSamples);
 
-    // So set up worker thread data
-    data->thread_info = info;
-    data->thread_finishedWorking = 0;
+    // Check if mixed data is ready from worker thread
+    startTime = s3eTimerGetMs();
+    while( !data->preBuffer_IsDataReady ) 
+    {
+        // No data is ready; but we CAN'T use s3eDeviceYield() nor Sleep()
+        // because that could call s3e_more_audio while we're already in it
+        // and that would break the code
+        //s3eDeviceYield(0);
 
-    // Signal our thread that it has work waiting for it
+        // If we are waiting for worker thread to finish mixing
+        // for more than 20ms, it most probably means that application
+        // is paused (suspended) or has received terminate signal
+        // So don't wait any more
+        if( s3eTimerGetMs() - startTime > 20 )
+        {
+            // We HAVE to return info->m_NumSamples instead of 0
+            // even though we haven't mixed any data. This is because
+            // Marmalade doesn't detect that application is paused/closed
+            // and will keep calling our callback function until it gets
+            // all the data it required.
+            // So at least clear output sound buffer so it would play silence.
+            //memset( info->m_Target, 0, info->m_NumSamples * data->bytesPerSample );
+            return info->m_NumSamples;
+            //return 0; // We can't return 0 - it would block the application
+        }
+
+        // Check if application has received quit request or is paused
+        // Unfortunately, this doesn't always work - that's why we have
+        // timer above which will exit this function if more than 20ms passed
+        // If any of those two functions return true, it means that
+        // Marmalade HAS recognized that it should be paused/terminated
+        // so we can properly return 0.
+        if( s3eDeviceCheckQuitRequest() || s3eDeviceCheckPauseRequest() ) return 0;
+    }
+
+    // Copy new data (note: data->preBufferData is a cyclic buffer)
+    dataWritten = min( info->m_NumSamples, data->preBuffer_DataLength );
+    if( data->preBuffer_DataStartIndex + dataWritten <= data->preBufferSize )
+    {
+        // Copy all data in 1 step
+        memcpy( info->m_Target, data->preBufferData + data->preBuffer_DataStartIndex*data->bytesPerSample, dataWritten * data->bytesPerSample );
+    } else {
+        // Copy data in 2 steps
+        len1 = data->preBufferSize - data->preBuffer_DataStartIndex;
+        memcpy( info->m_Target, data->preBufferData + data->preBuffer_DataStartIndex*data->bytesPerSample, len1 * data->bytesPerSample );
+        len2 = dataWritten - len1;
+        if( len2 > 0 ) memcpy( info->m_Target, data->preBufferData, len2 * data->bytesPerSample );
+    }
+    data->preBuffer_DataStartIndex += dataWritten;
+    if( data->preBuffer_DataStartIndex >= data->preBufferSize ) data->preBuffer_DataStartIndex -= data->preBufferSize;
+    data->preBuffer_DataLength -= dataWritten;
+
+    data->preBuffer_IsDataReady = 0;
+
+    // Signal to worker thread that it can pre-mix next piece of sound buffer
     // We can use semaphore in this case, because we will not block this thread
     // Worker thread will act immediately.
     s3eThreadSemPost(data->thread_semaphore);
 
-    // Wait for worker thread to finish with work
-    // And we can't wait with our semaphore... because it would block s3e thread and that's not allowed
-    // So we have to use volatile variable and Sleep() instead.
-    while( data->thread && data->thread_finishedWorking == 0 ) Sleep(0);
-
-    return info->m_NumSamples;
+    return dataWritten;
 }
 
 
-static ALCboolean s3e_open_playback(ALCdevice *device, const ALCchar *deviceName) {
-    if( !deviceName ) {
-        deviceName = s3eDevice;
-    } 
-    if( strcmp(s3eDevice, deviceName) == 0 ) {
-        s3e_data* data = (s3e_data*)malloc(sizeof(s3e_data));
-        data->channel = s3eSoundGetFreeChannel();
-        data->mix_data = NULL;
-        data->killNow = 0;
-        data->thread_semaphore = NULL;
-        data->thread_finishedWorking = 0;
-        data->thread_exited = 0;
-        device->ExtraData = data;
-        device->szDeviceName = strdup(deviceName);
-        device->FmtType = DevFmtShort;
+static ALCboolean s3e_open_playback( ALCdevice *device, const ALCchar *deviceName )
+{
+    s3e_data* data;
 
-        if( s3eSoundGetInt(S3E_SOUND_STEREO_ENABLED) ) {
-          device->FmtChans = DevFmtStereo;
-        } else {
-          device->FmtChans = DevFmtMono;
-        }
-        // when generating sound, channel frequency is ignored
-        device->Frequency = s3eSoundGetInt(S3E_SOUND_OUTPUT_FREQ);
+    if( !deviceName ) deviceName = s3eDevice;
+    if( strcmp(s3eDevice, deviceName) != 0 ) return ALC_FALSE;
 
-        return ALC_TRUE;
-    } else {
-        return ALC_FALSE;
-    }
+    data = (s3e_data*)malloc(sizeof(s3e_data));
+    data->channel = s3eSoundGetFreeChannel();
+    data->mix_data = NULL;
+    data->sampleSize = 0;
+    data->bytesPerSample = 0;
+    data->preBufferData = NULL;
+    data->preBufferSize = 0;
+    data->preBuffer_DataStartIndex = 0;
+    data->preBuffer_DataLength = 0;
+    data->thread = NULL;
+    data->killNow = 0;
+    data->thread_semaphore = NULL;
+    data->thread_exited = 0;
+    device->ExtraData = data;
+    device->szDeviceName = strdup(deviceName);
+    device->FmtType = DevFmtShort;  // 16 bit per channel
+
+    // Register callback functions
+    s3eSoundChannelRegister( data->channel, S3E_CHANNEL_GEN_AUDIO, s3e_more_audio, device );
+
+    // Check if we have stereo sound
+    if( s3eSoundGetInt(S3E_SOUND_STEREO_ENABLED) )
+    {
+        data->isStereo = s3eSoundChannelRegister( data->channel, S3E_CHANNEL_GEN_AUDIO_STEREO, s3e_more_audio, device ) == S3E_RESULT_SUCCESS;
+    } else data->isStereo = 0;
+    device->FmtChans = data->isStereo ? DevFmtStereo : DevFmtMono;
+
+    // when generating sound, channel frequency is ignored - we use output device frequency
+    device->Frequency = s3eSoundGetInt(S3E_SOUND_OUTPUT_FREQ);
+
+    return ALC_TRUE;
 }
 
 
-static void s3e_close_playback(ALCdevice *device) {
+static void s3e_close_playback( ALCdevice *device )
+{
     s3e_data *data = (s3e_data*)device->ExtraData;
+    device->ExtraData = NULL;
     s3eSoundChannelStop(data->channel);
     free(data);
-    device->ExtraData = NULL;
 }
 
-static ALCboolean s3e_reset_playback(ALCdevice *device) {
+static ALCboolean s3e_reset_playback( ALCdevice *device )
+{
     s3e_data *data = (s3e_data*)device->ExtraData;
-    int dataSize = device->UpdateSize * FrameSizeFromDevFmt(device->FmtChans, device->FmtType);
+    data->sampleSize = device->UpdateSize;
+    data->bytesPerSample = FrameSizeFromDevFmt(device->FmtChans, device->FmtType) * sizeof(ALubyte);
+    assert( data->bytesPerSample == (data->isStereo ? 4 : 2) );
 
-    data->mix_data = (ALubyte*)calloc(1, dataSize * sizeof(ALubyte));
-    if(!data->mix_data) {
+    data->mix_data = (ALubyte*)calloc(1, data->sampleSize * data->bytesPerSample);
+    if( !data->mix_data ) {
         AL_PRINT("buffer malloc failed\n");
         return ALC_FALSE;
     }
@@ -155,28 +286,33 @@ static ALCboolean s3e_reset_playback(ALCdevice *device) {
 
     // Create semaphore we will use to signal worker thread
     data->thread_semaphore = s3eThreadSemCreate(0);
+    // Create pre-buffer & initialize data
+    data->preBufferSize = data->sampleSize * 2;
+    data->preBufferData = (ALubyte*)calloc( 1, data->preBufferSize * data->bytesPerSample );
+    data->preBuffer_DataStartIndex = data->preBuffer_DataLength = 0;
+    data->preBuffer_IsDataReady = 0;
 
     // Start worker thread
     data->killNow = 0;
-    data->thread = StartThread(s3e_channel_thread, device);
-    if(data->thread == NULL)
+    data->thread = StartThread( s3e_channel_thread, device );
+    if( data->thread == NULL )
     {
         free(data->mix_data);
         data->mix_data = NULL;
+        free(data->preBufferData);
+        data->preBufferData = NULL;
         s3eThreadSemDestroy(data->thread_semaphore);
         return ALC_FALSE;
     }
 
-    // Register & start callback functions
-    s3eSoundChannelRegister(data->channel, S3E_CHANNEL_GEN_AUDIO, s3e_more_audio, device);
-    s3eSoundChannelRegister(data->channel, S3E_CHANNEL_GEN_AUDIO_STEREO, s3e_more_audio, device);
-
     // Starting infinite playback cycle with any data
-    s3eSoundChannelPlay(data->channel, (int16*)data->mix_data, dataSize, 0, 0);
+    //s3eSoundChannelPlay( data->channel, (int16*)data->mix_data, data->sampleSize * data->bytesPerSample, 0, 0 );
+    s3eSoundChannelPlay( data->channel, (int16*)data->mix_data, data->sampleSize * (data->isStereo ? 2 : 1), 0, 0 );
     return ALC_TRUE;
 }
 
-static void s3e_stop_playback(ALCdevice *device) {
+static void s3e_stop_playback( ALCdevice *device )
+{
     s3e_data *data = (s3e_data*)device->ExtraData;
     int i;
 
@@ -184,11 +320,12 @@ static void s3e_stop_playback(ALCdevice *device) {
     data->killNow = 1;
 
     // Stop the callback functions
-    s3eSoundChannelUnRegister(data->channel, S3E_CHANNEL_GEN_AUDIO_STEREO);
-    s3eSoundChannelUnRegister(data->channel, S3E_CHANNEL_GEN_AUDIO);
+    s3eSoundChannelStop(data->channel);
+    s3eSoundChannelUnRegister( data->channel, S3E_CHANNEL_GEN_AUDIO_STEREO );
+    s3eSoundChannelUnRegister( data->channel, S3E_CHANNEL_GEN_AUDIO );
 
     // Stop the thread
-    if(data->thread) {
+    if( data->thread ) {
         ALvoid *thread = (ALvoid*)data->thread;
         data->thread = NULL;    // Remove the pointer to thread before stopping it
 
@@ -206,9 +343,14 @@ static void s3e_stop_playback(ALCdevice *device) {
         free(data->mix_data);
         data->mix_data = NULL;
     }
+    if( data->preBufferData != NULL ) {
+        free(data->preBufferData);
+        data->preBufferData = NULL;
+    }
 }
 
-static ALCboolean s3e_open_capture(ALCdevice *pDevice, const ALCchar *deviceName) {
+static ALCboolean s3e_open_capture( ALCdevice *pDevice, const ALCchar *deviceName )
+{
     // maybe one day
     (void)pDevice;
     (void)deviceName;
@@ -231,9 +373,8 @@ BackendFuncs s3e_funcs = {
 void alc_s3e_init(BackendFuncs *func_list) {
     *func_list = s3e_funcs;
 }
-    
-void alc_s3e_deinit(void) {
 
+void alc_s3e_deinit(void) {
 }
 
 void alc_s3e_probe(int type) {


### PR DESCRIPTION
Almost completely rewritten s3esoundaudio.c - worker thread now uses its own buffer to pre-mix the sound data.

Also, removed usage of pthread_mutex as it is buggy in Marmalade, instead implemented recursive mutex with s3eThreadLock.

In general, this version should behave stable on all platforms - it has been tested on PC, Android and iOS.
Stable means that OpenAL and s3e sound thread and application are properly synchronized, it means that it won't freeze or crash your application on device suspend/resume, and that it won't hang your application when it should be closed.

Only negative side is that current implementation has lot of cracking in the sound on PC, but luckily on Android and iPhone/iPad/iPod it sounds good without cracking.

All this effort is only because Marmalade doesn't allow mutex locks inside s3e callback - something which definitely should be doable. Until they fix that, this will have to do.
